### PR TITLE
allow multiple worker threads for single task

### DIFF
--- a/tensorflow/core/kernels/data/experimental/data_service_dataset_op.cc
+++ b/tensorflow/core/kernels/data/experimental/data_service_dataset_op.cc
@@ -1035,9 +1035,7 @@ class DataServiceDatasetOp::Dataset : public DatasetBase {
 
     void UpdateWorkerThreads(IteratorContext* ctx) TF_LOCKS_EXCLUDED(mu_) {
       mutex_lock l(mu_);
-      const int64_t max_num_threads =
-          std::min<int64_t>(tasks_.size(), max_outstanding_requests_);
-      while (num_running_worker_threads_ < max_num_threads && !cancelled_ &&
+      while (num_running_worker_threads_ < max_outstanding_requests_ && !cancelled_ &&
              status_.ok() && !job_finished_) {
         VLOG(0) << "updateWorkerThread, num_running_worker_threads_: "
                 << num_running_worker_threads_


### PR DESCRIPTION
Reverted to how it was here: https://github.com/resulknad/ml-input-data-service/blob/f2b0f6640bab6200d3247e178849aa67a3791df5/tensorflow/core/kernels/data/experimental/data_service_dataset_op.cc#L817
